### PR TITLE
Make this package usable as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@
 * [multiple-git-hooks.sh](https://gist.github.com/mjackson/7e602a7aa357cfe37dadcc016710931b)
 
 ## Installation
+### Install it globally
 ```
-npm install git-hooks-utl -g
+npm i git-hooks-util -g
 ```
+or
+### Install as a dependency
+npm i git-hooks-util --save-dev
+
+> If you install it as a dependency, it will automatically init the module after installing
 
 ## Usage
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ npm i git-hooks-util -g
 ```
 or
 ### Install as a dependency
+```
 npm i git-hooks-util --save-dev
+```
 
 > If you install it as a dependency, it will automatically init the module after installing
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "bin": {
     "ghu": "./index.js"
   },
+  "postinstall": "npm start",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
I wanted to use this git hook manager because it enables multiple hooks (my project already uses some git hooks that I don't want to overwrite), but I couldn't _share_ my config with other teammates without having them running any extra tasks. Therefore, I've added a simple `npm start` script as a `postinstall` hook, so that the module executes right after it's added to any project via `npm i git-hooks-util`.  

Hope it makes sense :)